### PR TITLE
Fix the 7 day rolling rate calculator

### DIFF
--- a/app/Models/CasesModel.php
+++ b/app/Models/CasesModel.php
@@ -107,7 +107,8 @@ class CasesModel extends Model
       // Use last row for the totals.
       $last_area_case_row = end($area_cases);
 
-      // Calculate the rolling averages and rate, do not use most recent 3 days.
+      // The case rows to use for calculations, this should be 7 days.
+      // Do not use the first row, or the most recent 3 days.
       $cases_for_calculations = array_slice($area_cases, 1, -3);
 
       // The weekly case total.
@@ -134,6 +135,7 @@ class CasesModel extends Model
         'rolling_cases' => (string) $rolling_total,
         'rolling_avg'   => number_format($rolling_avg, 2),
         'rolling_rate'  => number_format($rolling_rate, 2),
+        // Remove the first, thats just for calculng the rolling rate.
         'cases'         => array_slice($area_cases, 1),
       ];
     }


### PR DESCRIPTION
- Fetch 11 days of cases.
- Strip out the last three, and 1st fetched.
- Preseve the 1st in the set to calculate the rate.
- Use the rate from the last in the calculated set - the 1st rate in the
  whole case set.

This should now reflect correctly the effective 7day rate, based on
process used at BHCC.