### PR TITLE
Restrict import to run once only for new cases

### DIFF
--- a/app/Controllers/Cases_csv_fetch.php
+++ b/app/Controllers/Cases_csv_fetch.php
@@ -4,7 +4,7 @@ use Config\Services;
 
 class Cases_csv_fetch extends BaseController
 {
-	public function index()
+	public function index($force = NULL)
 	{
 		// Check most recent case.
 		$most_recent_case_date = $this->casesModel->mostRecentCaseDate();
@@ -13,7 +13,7 @@ class Cases_csv_fetch extends BaseController
 		$next_download_timestamp = strtotime(($most_recent_case_date ?? '2020-01-01') . ' + 2 Days') + 61200;
 
 		// If not yet time to download new cases.
-		if (time() < $next_download_timestamp)
+		if (time() < $next_download_timestamp && $force != 'force')
 		{
 			// Set a message not yet time to download.
 			$output_values =

--- a/app/Controllers/Cases_csv_fetch.php
+++ b/app/Controllers/Cases_csv_fetch.php
@@ -6,75 +6,107 @@ class Cases_csv_fetch extends BaseController
 {
 	public function index()
 	{
-		// Fetch csv file.
-		// https://c19downloads.azureedge.net/downloads/csv/coronavirus-cases_latest.csv
-		$csv_file_url = 'https://coronavirus.data.gov.uk/downloads/csv/coronavirus-cases_latest.csv';
-		$curlRequest = Services::curlrequest();
-		$fileResponse = $curlRequest->request('GET', $csv_file_url);
-		if ($fileResponse->getStatusCode() == '200')
+		// Check most recent case.
+		$most_recent_case_date = $this->casesModel->mostRecentCaseDate();
+
+		// Unix timestamp for when to download next cases (4pm next day).
+		$next_download_timestamp = strtotime(($most_recent_case_date ?? '2020-01-01') . ' + 2 Days') + 61200;
+
+		// If not yet time to download new cases.
+		if (time() < $next_download_timestamp)
 		{
-			// Get file, decode and set up loop.
-			$file = $fileResponse->getBody();
-			$file = gzdecode($file);
-			$rows = explode("\n", $file);
-			$row_number = 0;
-			$headers = [];
-			$areas = [];
-			// Loop through each
-			foreach ($rows as $row)
+			// Set a message not yet time to download.
+			$output_values =
+			[
+				'message' => 'Not time to download yet!',
+				'most_recent_case_date' => $most_recent_case_date,
+				'next_download' => date('Y-m-d G:i', $next_download_timestamp),
+			];
+		}
+		else
+		{
+
+			// Fetch csv file.
+			// https://c19downloads.azureedge.net/downloads/csv/coronavirus-cases_latest.csv
+			$csv_file_url = 'https://coronavirus.data.gov.uk/downloads/csv/coronavirus-cases_latest.csv';
+			$curlRequest = Services::curlrequest();
+			$fileResponse = $curlRequest->request('GET', $csv_file_url);
+			if ($fileResponse->getStatusCode() == '200')
 			{
-				$data = str_getcsv($row);
-				// If 0 row - get headers
-				if ($row_number == 0)
+				// Get file, decode and set up loop.
+				$file = $fileResponse->getBody();
+				$file = gzdecode($file);
+				$rows = explode("\n", $file);
+				$row_number = 0;
+				$headers = [];
+				$areas = [];
+				// Loop through each
+				foreach ($rows as $row)
 				{
-					$headers = $data;
-					$row_number++;
-					continue;
-				}
-				if (count($headers) != count($data))
-				{
-      		// corrupt row
-      		continue;
-    	  }
-				$row_data = array_combine($headers, $data);
+					$data = str_getcsv($row);
+					// If 0 row - get headers
+					if ($row_number == 0)
+					{
+						$headers = $data;
+						$row_number++;
+						continue;
+					}
+					// corrupt row
+					if (count($headers) != count($data))
+					{
+	      		continue;
+	    	  }
 
-				// Area.
-				$area_key = $row_data['Area name'].$row_data['Area type'];
-				if (isset($areas[$area_key]))
-				{
-					$area_id = $areas[$area_key];
-				} else
-				{
-					$area_values =
+					// Make row into associative array
+					$row_data = array_combine($headers, $data);
+
+					// If this is todays date, skip it as data is unreliable.
+					if ($row_data['Specimen date'] == date('Y-m-d'))
+					{
+						continue;
+					}
+
+					// Area.
+					$area_key = $row_data['Area name'].$row_data['Area type'];
+					if (isset($areas[$area_key]))
+					{
+						$area_id = $areas[$area_key];
+					} else
+					{
+						$area_values =
+						[
+							'name' => $row_data['Area name'],
+							'type' => $row_data['Area type'],
+							'code' => $row_data['Area code'],
+						];
+						$area_id = $this->areasModel->updateOrInsert($area_values);
+						$areas[$area_key] = $area_id;
+					}
+
+					// Case row.
+					$case_row_values =
 					[
-						'name' => $row_data['Area name'],
-						'type' => $row_data['Area type'],
-						'code' => $row_data['Area code'],
-					];
-					$area_id = $this->areasModel->updateOrInsert($area_values);
-					$areas[$area_key] = $area_id;
+			      'area_id' => $area_id,
+			      'daily' => $row_data['Daily lab-confirmed cases'],
+			      'cumlitive' => $row_data['Cumulative lab-confirmed cases'],
+			      'rate' => $row_data['Cumulative lab-confirmed cases rate'],
+			      'date' => $row_data['Specimen date'],
+			    ];
+					$case_row_id = $this->casesModel->updateOrInsert($case_row_values);
+
+					$row_number++;
 				}
-
-				// Case row.
-				$case_row_values =
-				[
-		      'area_id' => $area_id,
-		      'daily' => $row_data['Daily lab-confirmed cases'],
-		      'cumlitive' => $row_data['Cumulative lab-confirmed cases'],
-		      'rate' => $row_data['Cumulative lab-confirmed cases rate'],
-		      'date' => $row_data['Specimen date'],
-		    ];
-				$case_row_id = $this->casesModel->updateOrInsert($case_row_values);
-
-				$row_number++;
 			}
+
+			// Output rows and areas fethced.
+			$output_values =
+			[
+				'rows' => $row_number,
+				'areas' => count($areas),
+			];
 		}
 
-		$output_values =
-		[
-			'rows' => $row_number,
-			'areas' => count($areas),
-		];
+		// Output response.
 		return $this->response->setJSON($output_values);
 	}
 

--- a/app/Models/CasesModel.php
+++ b/app/Models/CasesModel.php
@@ -29,7 +29,7 @@ class CasesModel extends Model
       // Insert
       $this->insert($values);
       $id = $this->db->insertId();
-    } else
+    } elseif ($values !== $existing_case_row)
     {
       // Update
       $id = $existing_case_row['id'];

--- a/app/Models/CasesModel.php
+++ b/app/Models/CasesModel.php
@@ -8,7 +8,7 @@ class CasesModel extends Model
 
   protected $allowedFields = ['area_id', 'daily', 'cumlitive', 'rate', 'date'];
 
-  protected function mostRecentCaseDate() {
+  public function mostRecentCaseDate() {
     $last_case = $this->asArray()
                       ->select('date')
                       ->orderBy('date', 'DESC')


### PR DESCRIPTION
This will check if after the schduled release time 5pm and download new cases.
Should also avoid importing duplicate case rows.

Will allow the import job to run a more reqular cron.
Also avoid import todays cases, as data for that date is unreliable.