### PR TITLE
Increase case summary to 14 days and use recent -4 days for calculation

### DIFF
--- a/app/Models/CasesModel.php
+++ b/app/Models/CasesModel.php
@@ -109,6 +109,7 @@ class CasesModel extends Model
 
       // The case rows to use for calculations, this should be 7 days.
       // Do not use the first row, or the most recent 4 days.
+      // See #9 for reasons.
       $cases_for_calculations = array_slice($area_cases, 1, -4);
 
       // The weekly case total.

--- a/app/Models/CasesModel.php
+++ b/app/Models/CasesModel.php
@@ -63,7 +63,7 @@ class CasesModel extends Model
 
     // Add date filter.
     $date_to = $this->mostRecentCaseDate();
-    $date_from = date('Y-m-d', strtotime($date_to . ' -10 days'));
+    $date_from = date('Y-m-d', strtotime($date_to . ' -14 days'));
     $this->where('date >=', $date_from);
 
     // Tables to select.
@@ -108,8 +108,8 @@ class CasesModel extends Model
       $last_area_case_row = end($area_cases);
 
       // The case rows to use for calculations, this should be 7 days.
-      // Do not use the first row, or the most recent 3 days.
-      $cases_for_calculations = array_slice($area_cases, 1, -3);
+      // Do not use the first row, or the most recent 4 days.
+      $cases_for_calculations = array_slice($area_cases, 1, -4);
 
       // The weekly case total.
       $rolling_total = array_sum(array_column($cases_for_calculations, 'daily'));

--- a/app/Views/components/summaries.php
+++ b/app/Views/components/summaries.php
@@ -7,7 +7,7 @@
     </div>
     <div class="summaries-info">
       <ul>
-        <li><sup>*</sup> 7 day cases exclude the most recent 3 days.</li>
+        <li><sup>*</sup> 7 day cases exclude the most recent 4 days.</li>
         <li><sup>**</sup> Per 100,000 people.</li>
       </ul>
       <p>Data from Public Health England / <a href="https://coronavirus.data.gov.uk/about-data">Coronavirus Dashboard</a>.</p>

--- a/app/Views/components/summary.php
+++ b/app/Views/components/summary.php
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div class="area-case-summary--details--cases">
-      <h3>Cases in the last 10 days</h3>
+      <h3>Cases in the last 14 days</h3>
       <table class="area-case-summary--details--cases--list">
         <thead class="hidden">
           <th>Date</th>


### PR DESCRIPTION
Fix #9
    
Match Uk Government and Local Authorities in excluding most recent 4 days from the rate calculation and show summary for 14 days.