### PR TITLE
Split fetch of csv into seperate area types

### DIFF
--- a/app/Controllers/Cases_csv_fetch.php
+++ b/app/Controllers/Cases_csv_fetch.php
@@ -81,6 +81,12 @@ class Cases_csv_fetch extends BaseController
   					{
   						continue;
   					}
+
+					// Skip over anything older than 15 days unless forced.
+  					if (strtotime($row_data['date']) < strtotime('-15 days') && empty($force))
+  					{
+  						continue;
+  					}
   
   					// Area.
   					$area_key = $row_data['areaName'].$row_data['areaType'];

--- a/app/Controllers/Cases_csv_fetch.php
+++ b/app/Controllers/Cases_csv_fetch.php
@@ -13,7 +13,7 @@ class Cases_csv_fetch extends BaseController
 		// Check most recent case.
 		$most_recent_case_date = $this->casesModel->mostRecentCaseDate($area_type);
 
-		// Unix timestamp for when to download next cases (4pm next day).
+		// Unix timestamp for when to download next cases (5pm next day).
 		$next_download_timestamp = strtotime(($most_recent_case_date ?? '2020-01-01') . ' + 2 Days') + 61200;
 
 		// If not yet time to download new cases.

--- a/app/Models/CasesModel.php
+++ b/app/Models/CasesModel.php
@@ -8,11 +8,20 @@ class CasesModel extends Model
 
   protected $allowedFields = ['area_id', 'daily', 'cumlitive', 'rate', 'rolling_rate', 'date'];
 
-  public function mostRecentCaseDate() {
-    $last_case = $this->asArray()
-                      ->select('date')
-                      ->orderBy('date', 'DESC')
-                      ->first();
+  public function mostRecentCaseDate($area_type = NULL) {
+    $this->asArray()
+         ->select('cases.date')
+         ->orderBy('date', 'DESC');
+
+    // If an area type is defined, join to areas table.
+    if (in_array($area_type, ['ltla', 'utla', 'region', 'nation']))
+    {
+      $this->join('areas', 'areas.id = cases.area_id', 'left')
+           ->where('areas.type', $area_type);
+    }
+
+    // Get and return the last date.
+    $last_case = $this->first();
     return $last_case['date'];
   }
 


### PR DESCRIPTION
Fix #16 

Add new parameter to cases-csv-fetch with the area type codes
(ltla, utla, region, nation).
If specified, only fetch the cases for that type.